### PR TITLE
Fix Issue #4 - Use postgres:16 instead of postgres for compatibility

### DIFF
--- a/exercises/core-08/check.sh
+++ b/exercises/core-08/check.sh
@@ -36,7 +36,7 @@ docker run -d \
   --name $CHECKER_CONTAINER_NAME \
   -e POSTGRES_PASSWORD=mysecretpassword \
   -v "$VOLUME_DIR_HOST_ABSOLUTE":"$VOLUME_DIR_CONTAINER" \
-  postgres >/dev/null
+  postgres:16 >/dev/null
 
 wait_for_postgres "$CHECKER_CONTAINER_NAME"
 

--- a/exercises/core-08/hint.md
+++ b/exercises/core-08/hint.md
@@ -12,7 +12,7 @@ Follow this sequence of commands to set up the persistent database.
       --name c8-postgres \
       -e POSTGRES_PASSWORD=mysecretpassword \
       -v "$(pwd)/pgdata":/var/lib/postgresql/data \
-      postgres
+      postgres:16
     ```
     *(Wait about 20 seconds for the database to initialize. Check its status with `docker logs c8-postgres`.)*
 
@@ -42,7 +42,7 @@ Follow this sequence of commands to set up the persistent database.
       --name c8-postgres \
       -e POSTGRES_PASSWORD=mysecretpassword \
       -v "$(pwd)/pgdata":/var/lib/postgresql/data \
-      postgres
+      postgres:16
     ```
     *(Wait a few moments for it to start.)*
 

--- a/exercises/core-08/prompt.md
+++ b/exercises/core-08/prompt.md
@@ -11,7 +11,7 @@ Your task is to create a persistent PostgreSQL database. You will run a containe
     mkdir pgdata
     ```
 
-2.  **Run a `postgres` container**. Name it `c8-postgres` and use a volume to mount your `pgdata` directory to the container's data directory (`/var/lib/postgresql/data`).
+2.  **Run a `postgres:16` container**. Name it `c8-postgres` and use a volume to mount your `pgdata` directory to the container's data directory (`/var/lib/postgresql/data`).
     *(Wait 15-20 seconds for the database to initialize the first time).*
 
 3.  **Create a table** using `docker exec` to run the `psql` client inside the container. The table should be named `dvd_rentals`.


### PR DESCRIPTION
Fixes issue #4 by changing PostgreSQL image in `prompt.md`, `hint.md`, and `check.sh` to use the tag for [PostgreSQL v16](https://hub.docker.com/layers/library/postgres/16/images/sha256-956173f583cf64179b3909cafb702df6f2edf31cebaa1cbf04a9be24b5e0482a)