### PR TITLE
Add Delay after Initial Container Spin-Up in Exercise 14 Check Script

### DIFF
--- a/exercises/core-14/check.sh
+++ b/exercises/core-14/check.sh
@@ -32,6 +32,9 @@ for name in "$WEB_CONTAINER_NAME" "$REDIS_CONTAINER_NAME"; do
   assert_container_running "$name"
 done
 
+log_info "Waiting for web app to connect to Redis..."
+sleep 3
+
 log_info "Verifying services are on the custom network..."
 for name in "$WEB_CONTAINER_NAME" "$REDIS_CONTAINER_NAME"; do
   # This inspect command checks if the container is attached to our specific network


### PR DESCRIPTION
Add a three second delay after initial spin-up of the containers by the Exercise 14 check script to allow time for the web app to connect to Redis. Observed behavior is that the check script fails without this delay.