### PR TITLE
feat: add Korean translations to all exercise prompts and hints

### DIFF
--- a/exercises/core-01/hint.md
+++ b/exercises/core-01/hint.md
@@ -1,3 +1,11 @@
 The `CMD` instruction in a Dockerfile specifies the command to run when a container starts. The command and its arguments should be in JSON array format (e.g., `["command", "arg1", "arg2"]`).
 
 Use `docker build` to build your image and `docker run` to check its output.
+
+---
+
+## 한국어
+
+Dockerfile의 `CMD` 명령어는 컨테이너가 시작될 때 실행할 명령을 지정합니다. 명령과 인자는 JSON 배열 형식으로 작성해야 합니다 (예: `["command", "arg1", "arg2"]`).
+
+`docker build`로 이미지를 빌드하고 `docker run`으로 출력을 확인하세요.

--- a/exercises/core-01/prompt.md
+++ b/exercises/core-01/prompt.md
@@ -5,3 +5,13 @@ This first exercise will verify that your Docker installation is working correct
 In this directory, you will find a `Dockerfile`. Your task is to modify it to run a container that outputs the text "Hello Docker".
 
 The verification script will build an image from your `Dockerfile` and check its output.
+
+---
+
+## 한국어
+
+이 첫 번째 연습 문제는 Docker 설치가 올바르게 작동하는지 확인합니다.
+
+이 디렉토리에서 `Dockerfile`을 찾을 수 있습니다. 여러분의 과제는 "Hello Docker"라는 텍스트를 출력하는 컨테이너를 실행하도록 이 파일을 수정하는 것입니다.
+
+검증 스크립트가 여러분의 `Dockerfile`로 이미지를 빌드하고 출력을 확인할 것입니다.

--- a/exercises/core-02/hint.md
+++ b/exercises/core-02/hint.md
@@ -1,3 +1,13 @@
 Use:
 ```bash
 docker run -d -p <HOST-PORT>:<CONTAINER-PORT> --name my-nginx nginx
+```
+
+---
+
+## 한국어
+
+다음 명령어를 사용하세요:
+```bash
+docker run -d -p <호스트-포트>:<컨테이너-포트> --name my-nginx nginx
+```

--- a/exercises/core-02/prompt.md
+++ b/exercises/core-02/prompt.md
@@ -6,3 +6,14 @@ Pull and run the official `nginx` image, expose port 80, and verify you can acce
 2. Name the container `my-nginx`.
 3. Map host port `8080` to container port `80`.
 4. Use `curl http://localhost:8080` to verify it's working.
+
+---
+
+## 한국어
+
+공식 `nginx` 이미지를 가져와서 실행하고, 포트 80을 노출하여 로컬에서 접근할 수 있는지 확인하세요.
+
+1. `nginx` 컨테이너를 실행하세요.
+2. 컨테이너 이름을 `my-nginx`로 지정하세요.
+3. 호스트 포트 `8080`을 컨테이너 포트 `80`에 매핑하세요.
+4. `curl http://localhost:8080`으로 작동을 확인하세요.

--- a/exercises/core-03/hint.md
+++ b/exercises/core-03/hint.md
@@ -15,3 +15,25 @@ Use the following commands to complete the exercise:
 Remember to stop and remove the container to keep your system clean:
 `docker stop <container-name>`
 `docker rm <container-name>`
+
+---
+
+## 한국어
+
+다음 명령어들을 사용하여 연습 문제를 완료하세요:
+
+- **이미지 빌드:**
+  `docker build -t <이미지-이름> .`
+
+- **분리 모드로 컨테이너 실행:**
+  `docker run -d --name <컨테이너-이름> <이미지-이름>`
+
+- **컨테이너에서 로그 가져오기:**
+  `docker logs <컨테이너-이름>`
+
+- **출력을 파일로 저장 (리다이렉션):**
+  `docker logs <컨테이너-이름> > logs.txt`
+
+시스템을 깔끔하게 유지하기 위해 컨테이너를 중지하고 제거하는 것을 잊지 마세요:
+`docker stop <컨테이너-이름>`
+`docker rm <컨테이너-이름>`

--- a/exercises/core-03/prompt.md
+++ b/exercises/core-03/prompt.md
@@ -21,3 +21,29 @@ In this directory, you will find a `Dockerfile`. Your task is to perform the fol
 3.  **Retrieve the logs** from the `my-logger` container using the `docker logs` command and save them to a file named `logs.txt` in this directory.
 
 The verification script will check if the `logs.txt` file exists and if its content is correct. After you have captured the logs, you can clean up by stopping and removing the container.
+
+---
+
+## 한국어
+
+이 연습 문제에서는 컨테이너에서 로그를 가져오는 방법을 배웁니다. 이는 Docker 내에서 실행되는 애플리케이션을 디버깅하는 데 필수적인 기술입니다.
+
+컨테이너의 표준 출력과 표준 에러 스트림은 캡처되어 컨테이너의 수명 주기 동안 언제든지 접근할 수 있습니다.
+
+## 과제
+
+이 디렉토리에서 `Dockerfile`을 찾을 수 있습니다. 다음 단계를 수행하세요:
+
+1.  이 디렉토리의 `Dockerfile`에서 Docker 이미지를 **빌드**하세요. 기억하기 쉬운 태그를 지정하세요 (예: `logging-app`).
+    ```bash
+    docker build -t logging-app .
+    ```
+
+2.  이미지를 **분리 모드** (`-d`)로 **실행**하세요. 이렇게 하면 컨테이너가 백그라운드에서 계속 실행되어 프로세스가 종료된 후에도 로그를 가져올 수 있습니다. 쉽게 참조할 수 있도록 컨테이너에 이름을 지정하세요 (예: `my-logger`).
+    ```bash
+    docker run -d --name my-logger logging-app
+    ```
+
+3.  `docker logs` 명령을 사용하여 `my-logger` 컨테이너에서 **로그를 가져와** 이 디렉토리에 `logs.txt` 파일로 저장하세요.
+
+검증 스크립트가 `logs.txt` 파일이 존재하는지와 내용이 올바른지 확인할 것입니다. 로그를 캡처한 후에는 컨테이너를 중지하고 제거하여 정리할 수 있습니다.

--- a/exercises/core-04/hint.md
+++ b/exercises/core-04/hint.md
@@ -23,3 +23,33 @@ Use this sequence of commands to solve the exercise.
     ```bash
     docker cp c4-container:/tmp/container-info.txt .
     ```
+
+---
+
+## 한국어
+
+다음 순서의 명령어들을 사용하여 연습 문제를 해결하세요.
+
+1.  **컨테이너 *안으로* 파일 복사:**
+    구문은 `docker cp <호스트-경로> <컨테이너-이름>:<컨테이너-경로>`입니다.
+    ```bash
+    docker cp run-inside-container.sh c4-container:/tmp/
+    ```
+
+2.  **스크립트를 실행 가능하게 만들기:**
+    `docker exec`를 사용하여 컨테이너 내부에서 `chmod` 명령을 실행해야 합니다.
+    ```bash
+    docker exec c4-container chmod +x /tmp/run-inside-container.sh
+    ```
+
+3.  **스크립트 실행:**
+    다시 `docker exec`를 사용하여 방금 복사한 스크립트를 실행하세요.
+    ```bash
+    docker exec c4-container /tmp/run-inside-container.sh
+    ```
+
+4.  **컨테이너 *밖으로* 결과 파일 복사:**
+    구문은 `docker cp <컨테이너-이름>:<컨테이너-경로> <호스트-경로>`입니다.
+    ```bash
+    docker cp c4-container:/tmp/container-info.txt .
+    ```

--- a/exercises/core-04/prompt.md
+++ b/exercises/core-04/prompt.md
@@ -22,3 +22,30 @@ Your task is to copy a script into a running Nginx container, execute it, and th
 The verification script will then check this `container-info.txt` file for the correct content.
 
 **Cleanup:** When you are done, stop and remove the container: `docker stop c4-container && docker rm c4-container`.
+
+---
+
+## 한국어
+
+이 연습 문제에서는 실행 중인 컨테이너에서 파일을 관리하고 명령을 실행하는 전체 워크플로우를 배웁니다. 이를 증명하기 위해 직접 파일 내용을 만들지 않고, 컨테이너 내부에서 스크립트를 실행하여 내용을 생성합니다.
+
+## 과제
+
+실행 중인 Nginx 컨테이너에 스크립트를 복사하고, 실행한 다음, 결과 출력 파일을 호스트 머신으로 다시 복사하는 것이 과제입니다.
+
+1.  `nginx` 이미지에서 분리 모드로 **컨테이너를 실행**하세요. 이름은 `c4-container`로 지정하세요.
+    ```bash
+    docker run -d --name c4-container nginx
+    ```
+
+2.  호스트에서 컨테이너로 **스크립트를 복사**하세요. 이 디렉토리에 제공된 `run-inside-container.sh` 스크립트를 컨테이너 내부의 `/tmp` 디렉토리로 복사하세요.
+
+3.  `docker exec`를 사용하여 컨테이너 내부에서 **스크립트를 실행 가능하게** 만드세요.
+
+4.  마찬가지로 `docker exec`를 사용하여 컨테이너 내부에서 **스크립트를 실행**하세요. 스크립트가 `/tmp/container-info.txt`에 새 파일을 생성합니다.
+
+5.  컨테이너에서 호스트의 현재 디렉토리로 **출력 파일** (`/tmp/container-info.txt`)을 **복사**하세요.
+
+검증 스크립트가 이 `container-info.txt` 파일의 내용이 올바른지 확인할 것입니다.
+
+**정리:** 완료되면 컨테이너를 중지하고 제거하세요: `docker stop c4-container && docker rm c4-container`.

--- a/exercises/core-05/hint.md
+++ b/exercises/core-05/hint.md
@@ -10,3 +10,20 @@ A `Dockerfile` is a sequence of instructions. Here are the key ones you'll need:
     ```
 -   **`EXPOSE 5000`**: Informs Docker that the application listens on this port. This is good practice for documentation.
 -   **`CMD ["python", "app.py"]`**: Provides the default command to execute when the container starts. You should use the JSON array format for commands.
+
+---
+
+## 한국어
+
+`Dockerfile`은 일련의 명령어입니다. 다음은 필요한 주요 명령어들입니다:
+
+-   **`FROM python:3.9-slim`**: 빌드를 위한 시작 이미지를 지정합니다.
+-   **`WORKDIR /app`**: 이후 모든 명령 (`COPY`, `RUN`, `CMD`)의 현재 디렉토리를 설정합니다.
+-   **`COPY <소스> <대상>`**: 호스트에서 이미지로 파일을 복사합니다.
+    *팁: 빌드 캐싱을 최적화하려면 나머지 애플리케이션 코드를 복사하기 *전에* `requirements.txt`를 복사하고 `pip install`을 실행해야 합니다.*
+-   **`RUN <명령>`**: 이미지 빌드 중에 명령을 실행합니다. 의존성 설치에 사용됩니다.
+    ```
+    RUN pip install -r requirements.txt
+    ```
+-   **`EXPOSE 5000`**: 애플리케이션이 이 포트에서 수신 대기한다고 Docker에 알립니다. 문서화를 위한 좋은 관행입니다.
+-   **`CMD ["python", "app.py"]`**: 컨테이너가 시작될 때 실행할 기본 명령을 제공합니다. 명령에는 JSON 배열 형식을 사용해야 합니다.

--- a/exercises/core-05/prompt.md
+++ b/exercises/core-05/prompt.md
@@ -20,3 +20,28 @@ Your `Dockerfile` should perform the following steps:
 7.  Set the default command to run the Flask application when a container starts.
 
 Once you have created your `Dockerfile`, the `check` command will build it and test if your application container runs correctly.
+
+---
+
+## 한국어
+
+이제 직접 커스텀 이미지를 만들 시간입니다!
+
+`nginx`와 같은 미리 빌드된 이미지를 실행하는 것도 유용하지만, Docker의 진정한 힘은 자신만의 애플리케이션을 패키징하는 데 있습니다. 이는 `Dockerfile`이라는 파일에 일련의 명령어를 작성하여 수행됩니다.
+
+## 과제
+
+이 디렉토리에서 간단한 Python Flask 애플리케이션 (`app.py`)과 그 의존성 (`requirements.txt`)을 찾을 수 있습니다.
+
+이 애플리케이션을 이미지로 패키징하는 **`Dockerfile`을 생성**하는 것이 과제입니다.
+
+`Dockerfile`은 다음 단계를 수행해야 합니다:
+1.  적합한 Python 기본 이미지에서 시작합니다 (예: `python:3.9-slim`).
+2.  이미지 내부에 작업 디렉토리를 설정합니다 (예: `/app`).
+3.  `requirements.txt` 파일을 이미지로 복사합니다.
+4.  `pip`를 사용하여 Python 의존성을 설치합니다.
+5.  애플리케이션 소스 코드 (`app.py`)를 이미지로 복사합니다.
+6.  런타임에 컨테이너가 포트 `5000`에서 수신 대기한다고 Docker에 알립니다.
+7.  컨테이너가 시작될 때 Flask 애플리케이션을 실행하는 기본 명령을 설정합니다.
+
+`Dockerfile`을 생성한 후, `check` 명령이 이를 빌드하고 애플리케이션 컨테이너가 올바르게 실행되는지 테스트합니다.

--- a/exercises/core-06/hint.md
+++ b/exercises/core-06/hint.md
@@ -17,3 +17,29 @@ Here are the `Dockerfile` instructions you'll need.
 -   **`CMD`**: The `app.py` script has been written to read the `PORT` from the environment variables, so you just need to execute the script.
     ```Dockerfile
     CMD ["python", "app.py"]
+    ```
+
+---
+
+## 한국어
+
+다음은 필요한 `Dockerfile` 명령어들입니다.
+
+-   **`LABEL`**: 키-값 메타데이터를 추가하는 데 사용됩니다. 기본 이미지와의 충돌을 피하기 위해 고유한 키를 사용하세요.
+    ```Dockerfile
+    LABEL org.dockerlings.author="your.name@example.com"
+    ```
+
+-   **`ENV`**: 환경 변수를 설정합니다. 컨테이너 프로세스가 이 변수를 상속받습니다.
+    ```Dockerfile
+    ENV PORT=8000
+    ```
+
+-   **`EXPOSE`**: 애플리케이션이 사용하는 포트를 문서화하는 것이 좋은 관행입니다.
+    ```Dockerfile
+    EXPOSE 8000
+    ```
+-   **`CMD`**: `app.py` 스크립트는 환경 변수에서 `PORT`를 읽도록 작성되었으므로, 스크립트만 실행하면 됩니다.
+    ```Dockerfile
+    CMD ["python", "app.py"]
+    ```

--- a/exercises/core-06/prompt.md
+++ b/exercises/core-06/prompt.md
@@ -15,3 +15,23 @@ In this directory, you will find a `Dockerfile` and a simple Python Flask applic
 3.  **Modify the `CMD`** instruction to use the `$PORT` environment variable to run the Flask application on the correct port. The application (`app.py`) is already written to read this environment variable.
 
 The verification script will build your `Dockerfile`, inspect it for the correct `LABEL` and `ENV`, and then run it to ensure the application starts on the port you specified.
+
+---
+
+## 한국어
+
+이 연습 문제에서는 메타데이터를 추가하고 이미지를 더 구성 가능하게 만드는 `Dockerfile` 명령어들을 소개합니다.
+
+- `LABEL`: 유지보수자 이메일이나 버전 번호와 같은 메타데이터를 이미지에 추가합니다.
+- `ENV`: 빌드 중과 이미지에서 컨테이너가 실행될 때 사용할 수 있는 영구 환경 변수를 설정합니다.
+- `CMD`: 컨테이너가 시작될 때 실행할 기본 명령을 지정합니다. 환경 변수를 어떻게 사용할 수 있는지 살펴보겠습니다.
+
+## 과제
+
+이 디렉토리에서 `Dockerfile`과 간단한 Python Flask 애플리케이션을 찾을 수 있습니다. 다음을 수행하도록 **`Dockerfile`을 수정**하는 것이 과제입니다:
+
+1.  이미지에 **`LABEL`을 추가**하세요. 키는 `org.dockerlings.author`이고 값은 여러분의 이름이나 이메일이어야 합니다 (예: `"Jane Doe <jane.doe@example.com>"`).
+2.  값이 `8000`인 `PORT`라는 이름의 **`ENV` 변수를 설정**하세요.
+3.  `$PORT` 환경 변수를 사용하여 올바른 포트에서 Flask 애플리케이션을 실행하도록 **`CMD` 명령어를 수정**하세요. 애플리케이션 (`app.py`)은 이미 이 환경 변수를 읽도록 작성되어 있습니다.
+
+검증 스크립트가 `Dockerfile`을 빌드하고, 올바른 `LABEL`과 `ENV`를 검사한 다음, 지정한 포트에서 애플리케이션이 시작되는지 확인하기 위해 실행합니다.

--- a/exercises/core-07/hint.md
+++ b/exercises/core-07/hint.md
@@ -12,3 +12,22 @@ To complete this exercise, you'll need to use the `COPY` instruction.
     ```
 
 **Note:** The trailing slash on the source (`html/`) is important. It tells Docker to copy the contents of the directory, not the directory itself.
+
+---
+
+## 한국어
+
+이 연습 문제를 완료하려면 `COPY` 명령어를 사용해야 합니다.
+
+-   **`FROM <이미지>`**: 기본 이미지로 `Dockerfile`을 시작합니다. `nginx:stable-alpine`은 작고 효율적이므로 좋은 선택입니다.
+    ```Dockerfile
+    FROM nginx:stable-alpine
+    ```
+
+-   **`COPY <소스> <대상>`**: 복사 구문은 간단합니다. `<소스>`는 빌드 컨텍스트(현재 디렉토리)에 대한 상대 경로이고, `<대상>`은 이미지 내부의 절대 경로입니다.
+    ```Dockerfile
+    # 'html' 디렉토리의 *내용*을 복사합니다
+    COPY html/ /usr/share/nginx/html/
+    ```
+
+**참고:** 소스의 후행 슬래시 (`html/`)가 중요합니다. 이는 Docker에게 디렉토리 자체가 아닌 디렉토리의 내용을 복사하라고 지시합니다.

--- a/exercises/core-07/prompt.md
+++ b/exercises/core-07/prompt.md
@@ -15,3 +15,23 @@ Your `Dockerfile` should:
 2.  Use the `COPY` instruction to copy the contents of the `html` directory into the location where Nginx serves its static files from, which is `/usr/share/nginx/html`.
 
 The verification script will build your image, run it, and check to see if your custom website is being served correctly.
+
+---
+
+## 한국어
+
+지금까지 Python 애플리케이션을 패키징하여 이미지를 빌드했습니다. Docker의 일반적인 사용 사례 중 하나는 정적 웹사이트를 패키징하고 서비스하는 것입니다.
+
+`COPY` 명령어는 `Dockerfile`에서 가장 기본적인 명령 중 하나입니다. 로컬 파일 시스템(빌드 컨텍스트)에서 생성 중인 이미지로 파일과 디렉토리를 복사할 수 있습니다.
+
+## 과제
+
+이 디렉토리에서 간단한 웹사이트가 포함된 `html` 하위 디렉토리를 찾을 수 있습니다.
+
+기본 Nginx 환영 페이지 대신 이 커스텀 정적 콘텐츠를 서비스하는 새 Nginx 이미지를 빌드하는 **`Dockerfile`을 생성**하는 것이 과제입니다.
+
+`Dockerfile`은 다음을 수행해야 합니다:
+1.  `nginx:stable-alpine`과 같은 경량 Nginx 이미지에서 시작합니다.
+2.  `COPY` 명령어를 사용하여 `html` 디렉토리의 내용을 Nginx가 정적 파일을 서비스하는 위치인 `/usr/share/nginx/html`로 복사합니다.
+
+검증 스크립트가 이미지를 빌드하고, 실행하고, 커스텀 웹사이트가 올바르게 서비스되는지 확인합니다.

--- a/exercises/core-08/hint.md
+++ b/exercises/core-08/hint.md
@@ -50,3 +50,60 @@ Follow this sequence of commands to set up the persistent database.
     ```bash
     docker exec c8-postgres psql -U postgres -c "SELECT * FROM dvd_rentals;"
     ```
+
+---
+
+## 한국어
+
+다음 명령어 순서를 따라 영구 데이터베이스를 설정하세요.
+
+1.  **호스트 디렉토리 생성:**
+    ```bash
+    mkdir pgdata
+    ```
+
+2.  **첫 번째 컨테이너 인스턴스 실행:**
+    `-v "$(pwd)/pgdata:/var/lib/postgresql/data"` 플래그가 새 로컬 디렉토리를 컨테이너에 매핑합니다.
+    ```bash
+    docker run -d \
+      --name c8-postgres \
+      -e POSTGRES_PASSWORD=mysecretpassword \
+      -v "$(pwd)/pgdata":/var/lib/postgresql/data \
+      postgres:16
+    ```
+    *(데이터베이스 초기화를 위해 약 20초 정도 기다리세요. `docker logs c8-postgres`로 상태를 확인할 수 있습니다.)*
+
+3.  **데이터베이스 내부에 테이블 생성:**
+    `docker exec`를 사용하여 기본 `postgres` 사용자로 `psql` 명령을 실행하세요.
+    ```bash
+    docker exec c8-postgres psql -U postgres -c "CREATE TABLE dvd_rentals (title TEXT);"
+    ```
+
+4.  **특정 데이터 행 삽입:**
+    ```bash
+    docker exec c8-postgres psql -U postgres -c "INSERT INTO dvd_rentals (title) VALUES ('The Grand Budapest Hotel');"
+    ```
+
+---
+
+### 직접 확인하는 방법 ("아하" 순간)
+
+1.  **컨테이너 삭제:**
+    ```bash
+    docker stop c8-postgres && docker rm c8-postgres
+    ```
+
+2.  **같은 데이터에 새 컨테이너 인스턴스 실행:**
+    ```bash
+    docker run -d \
+      --name c8-postgres \
+      -e POSTGRES_PASSWORD=mysecretpassword \
+      -v "$(pwd)/pgdata":/var/lib/postgresql/data \
+      postgres:16
+    ```
+    *(시작될 때까지 잠시 기다리세요.)*
+
+3.  **데이터가 여전히 있는지 확인:**
+    ```bash
+    docker exec c8-postgres psql -U postgres -c "SELECT * FROM dvd_rentals;"
+    ```

--- a/exercises/core-08/prompt.md
+++ b/exercises/core-08/prompt.md
@@ -30,3 +30,38 @@ This is the core concept of volumes. To see it in action:
 ### Final State
 
 To complete the exercise, the checker needs to find the `pgdata` directory containing the database with the `dvd_rentals` table and the correct row. You can **leave the container running or stopped**, as the checker will only inspect the `pgdata` directory itself.
+
+---
+
+## 한국어
+
+컨테이너는 휘발성입니다. 즉, 컨테이너 내부에서 변경한 내용은 컨테이너가 제거되면 사라집니다. 데이터베이스와 같은 애플리케이션의 경우 데이터가 지속되어야 합니다. 이 연습 문제에서는 **볼륨**이 호스트 머신의 디렉토리를 컨테이너 내부의 디렉토리에 연결하여 이 문제를 해결하는 방법을 보여줍니다.
+
+## 과제
+
+영구적인 PostgreSQL 데이터베이스를 만드는 것이 과제입니다. 컨테이너를 실행하고, 데이터를 추가하고, 컨테이너를 제거한 다음, 데이터가 호스트 머신에 여전히 안전하게 있는지 확인합니다.
+
+1.  호스트 머신에 `pgdata`라는 이름의 **디렉토리를 생성**하세요. 이 디렉토리가 데이터베이스 파일을 보관합니다.
+    ```bash
+    mkdir pgdata
+    ```
+
+2.  **`postgres:16` 컨테이너를 실행**하세요. 이름을 `c8-postgres`로 지정하고 볼륨을 사용하여 `pgdata` 디렉토리를 컨테이너의 데이터 디렉토리 (`/var/lib/postgresql/data`)에 마운트하세요.
+    *(처음에는 데이터베이스 초기화를 위해 15-20초 정도 기다리세요).*
+
+3.  `docker exec`를 사용하여 컨테이너 내부에서 `psql` 클라이언트를 실행하여 **테이블을 생성**하세요. 테이블 이름은 `dvd_rentals`여야 합니다.
+
+4.  새 테이블에 **행을 삽입**하세요. 행에는 `The Grand Budapest Hotel`이라는 제목이 포함되어야 합니다.
+
+### "아하" 순간 (적극 권장)
+
+이것이 볼륨의 핵심 개념입니다. 실제로 확인하려면:
+
+1.  **컨테이너를 중지하고 제거**하세요: `docker stop c8-postgres && docker rm c8-postgres`.
+2.  컨테이너는 사라졌지만, 호스트의 `pgdata` 디렉토리는 남아 있습니다.
+3.  이전과 *똑같은 `docker run` 명령*을 사용하여 **새 컨테이너를 실행**하세요.
+4.  **데이터를 확인**하세요: 이 새 컨테이너에 `exec`로 들어가서 `SELECT * FROM dvd_rentals;`를 실행하세요. 이전에 추가한 영화 제목이 다시 나타나는 것을 볼 수 있습니다!
+
+### 최종 상태
+
+연습 문제를 완료하려면, 검사기가 `dvd_rentals` 테이블과 올바른 행이 있는 데이터베이스가 포함된 `pgdata` 디렉토리를 찾아야 합니다. 검사기는 `pgdata` 디렉토리 자체만 검사하므로 **컨테이너를 실행 중이거나 중지된 상태로 둘 수 있습니다**.

--- a/exercises/core-09/hint.md
+++ b/exercises/core-09/hint.md
@@ -10,3 +10,22 @@ docker run -d \
   -p 8009:80 \
   -v "$(pwd)/app":/usr/share/nginx/html:ro \
   nginx
+```
+
+---
+
+## 한국어
+
+바인드 마운트를 위해 `-v` 플래그와 함께 `docker run` 명령을 사용하세요. 형식은 `-v <호스트-경로>:<컨테이너-경로>`입니다.
+
+- 현재 디렉토리의 절대 경로를 얻으려면 `$(pwd)`를 사용할 수 있습니다.
+- 마운트를 읽기 전용으로 만들려면 끝에 `:ro`를 추가하세요.
+
+전체 명령 구조는 다음과 같습니다:
+```bash
+docker run -d \
+  --name c9-dev-server \
+  -p 8009:80 \
+  -v "$(pwd)/app":/usr/share/nginx/html:ro \
+  nginx
+```

--- a/exercises/core-09/prompt.md
+++ b/exercises/core-09/prompt.md
@@ -27,3 +27,35 @@ This is the core benefit of a bind mount. It's good practice to confirm your dev
 4.  Run `curl http://localhost:8009` again **without restarting the container**. You will see your new message served immediately from the container.
 
 **To complete the exercise, leave the container running.** The checker will perform a similar test automatically to verify your solution.
+
+---
+
+## 한국어
+
+볼륨은 데이터를 유지하는 데 좋지만, 애플리케이션을 개발할 때는 어떨까요? 코드 한 줄을 변경할 때마다 이미지를 다시 빌드하고 싶지는 않을 것입니다.
+
+이때 **바인드 마운트**가 등장합니다. 바인드 마운트는 호스트 머신의 디렉토리나 파일을 컨테이너에 직접 연결합니다. 호스트에서 변경한 내용이 컨테이너 내부에 즉시 반영되어 실시간 개발 워크플로우에 완벽합니다.
+
+## 과제
+
+`nginx` 컨테이너를 실행하고 제공된 `app` 디렉토리에서 간단한 정적 웹사이트를 서비스하는 것이 과제입니다. 핵심은 바인드 마운트를 사용하여 호스트 머신에서 웹사이트를 변경하면 재시작이나 재빌드 없이 즉시 반영되도록 하는 것입니다.
+
+1.  **`app/index.html` 파일을 확인**하세요. 이 파일이 서비스할 파일입니다.
+
+2.  **`nginx` 컨테이너를 실행**하세요.
+    - 이름을 `c9-dev-server`로 지정하세요.
+    - 호스트 포트 `8009`를 컨테이너 포트 `80`에 매핑하세요.
+    - **중요**: 로컬 `./app` 디렉토리를 컨테이너 내부의 Nginx 웹 루트 디렉토리 (`/usr/share/nginx/html`)에 매핑하는 바인드 마운트를 생성하세요. 정적 콘텐츠 서비스의 모범 사례를 따르기 위해 읽기 전용으로 만드세요.
+
+3.  **작동을 확인**하세요. 컨테이너가 실행되면 `curl http://localhost:8009`로 내용을 확인하세요. "Version 1" 헤딩이 보여야 합니다.
+
+### 좋은 관행: 실시간 리로드 테스트
+
+이것이 바인드 마운트의 핵심 이점입니다. 개발 설정이 예상대로 작동하는지 확인하는 것이 좋은 관행입니다. 실제로 확인하려면:
+
+1.  로컬 머신에서 텍스트 편집기로 `app/index.html` 파일을 여세요.
+2.  `<h1>` 태그 안의 텍스트를 "Version 1"에서 "My Live Update!"로 변경하세요.
+3.  파일을 저장하세요.
+4.  **컨테이너를 재시작하지 않고** `curl http://localhost:8009`를 다시 실행하세요. 새 메시지가 컨테이너에서 즉시 서비스되는 것을 볼 수 있습니다.
+
+**연습 문제를 완료하려면 컨테이너를 실행 상태로 두세요.** 검사기가 유사한 테스트를 자동으로 수행하여 솔루션을 확인합니다.

--- a/exercises/core-10/hint.md
+++ b/exercises/core-10/hint.md
@@ -26,3 +26,36 @@ Here are the commands you'll need.
     ```
 
 Put these `docker run` commands into the `run-containers.sh` script.
+
+---
+
+## 한국어
+
+다음은 필요한 명령어들입니다.
+
+1.  **네트워크 생성:**
+    ```bash
+    docker network create c10-network
+    ```
+
+2.  **특정 네트워크에서 컨테이너 실행:**
+    `docker run` 명령에서 `--network` 플래그를 사용하세요.
+
+    데이터베이스 컨테이너의 경우:
+    ```bash
+    docker run -d \
+      --name c10-db \
+      --network c10-network \
+      -e POSTGRES_PASSWORD=mysecretpassword \
+      postgres:14-alpine
+    ```
+
+    애플리케이션 컨테이너의 경우:
+    ```bash
+    docker run -d \
+      --name c10-app \
+      --network c10-network \
+      busybox sleep 3600
+    ```
+
+이 `docker run` 명령들을 `run-containers.sh` 스크립트에 넣으세요.

--- a/exercises/core-10/prompt.md
+++ b/exercises/core-10/prompt.md
@@ -17,3 +17,25 @@ Your task is to create a network and a script that launches two containers on th
     *   The `busybox` container should be kept running with a long-running command like `sleep 3600`.
 
 The verification script will execute your `run-containers.sh` script and then test if the `c10-app` container can successfully ping the `c10-db` container by its name.
+
+---
+
+## 한국어
+
+기본적으로 컨테이너는 외부 세계와 통신할 수 있지만, 서로를 발견하고 통신하는 능력은 제한적입니다. 연결할 수도 있지만, 현대적이고 권장되는 접근 방식은 커스텀 **브릿지 네트워크**를 사용하는 것입니다.
+
+여러 컨테이너를 같은 커스텀 네트워크에 배치하면, 컨테이너 이름을 호스트 이름으로 사용하여 서로를 찾고 통신할 수 있는 내부 DNS 서비스를 얻습니다. 이는 멀티 서비스 애플리케이션(예: 데이터베이스와 통신하는 웹 서버)을 구축하는 데 기본이 됩니다.
+
+## 과제
+
+네트워크를 생성하고 해당 네트워크에서 두 개의 컨테이너를 실행하는 스크립트를 작성하는 것이 과제입니다.
+
+1.  **커스텀 브릿지 네트워크를 생성**하고 `c10-network`라고 이름 지정하세요. 터미널에서 일회성 명령으로 수행할 수 있습니다.
+
+2.  이 디렉토리에 제공된 **`run-containers.sh` 스크립트를 편집**하세요. 스크립트는 다음 작업을 수행해야 합니다:
+    *   `c10-db`라는 이름의 `postgres:14-alpine` 컨테이너를 실행합니다.
+    *   `c10-app`이라는 이름의 `busybox` 컨테이너를 실행합니다.
+    *   **두 컨테이너 모두** 생성한 `c10-network`에 연결되어야 합니다.
+    *   `busybox` 컨테이너는 `sleep 3600`과 같은 장시간 실행 명령으로 계속 실행되어야 합니다.
+
+검증 스크립트가 `run-containers.sh` 스크립트를 실행한 다음 `c10-app` 컨테이너가 이름으로 `c10-db` 컨테이너를 성공적으로 ping할 수 있는지 테스트합니다.

--- a/exercises/core-11/hint.md
+++ b/exercises/core-11/hint.md
@@ -11,3 +11,21 @@
     
     docker run -d --name c11-server -p 8011:8080 c11-app
     ```
+
+---
+
+## 한국어
+
+1.  **Dockerfile에서:**
+    `EXPOSE` 명령은 단순히 포트 번호를 받습니다.
+    ```Dockerfile
+    EXPOSE 8080
+    ```
+
+2.  **명령줄에서:**
+    `-p` 플래그가 호스트 포트를 컨테이너 포트에 매핑합니다.
+    ```bash
+    # 사용법: docker run -d --name <컨테이너_이름> -p <호스트_포트>:<컨테이너_포트> <이미지_이름>
+    
+    docker run -d --name c11-server -p 8011:8080 c11-app
+    ```

--- a/exercises/core-11/prompt.md
+++ b/exercises/core-11/prompt.md
@@ -22,3 +22,30 @@ Your task is to correctly document and run a web application container.
     - Publish the exposed container port (`8080`) to port `8011` on your host machine.
 
 **To complete the exercise, leave the container running.** The checker will inspect both your built image and the running container to ensure they are configured correctly.
+
+---
+
+## 한국어
+
+초보자들이 흔히 혼동하는 부분은 `Dockerfile`의 `EXPOSE`와 `docker run`에서 사용하는 `--publish` (또는 `-p`) 플래그의 차이입니다.
+
+-   **`EXPOSE <포트>`**: 이것은 문서화 명령입니다. 컨테이너를 실행하는 사람에게 내부 애플리케이션이 수신 대기하는 포트를 알려줍니다. 포트를 열거나 호스트에서 접근 가능하게 만들지는 **않습니다**.
+
+-   **`docker run -p <호스트_포트>:<컨테이너_포트>`**: 이것은 런타임 명령입니다. 호스트 머신의 포트에서 컨테이너 내부의 포트로 트래픽을 매핑하는 네트워크 규칙을 적극적으로 생성합니다.
+
+## 과제
+
+웹 애플리케이션 컨테이너를 올바르게 문서화하고 실행하는 것이 과제입니다.
+
+1.  **`Dockerfile`을 수정**하세요. 제공된 `Dockerfile` 내부에 애플리케이션이 포트 **8080**에서 수신 대기한다는 것을 문서화하는 `EXPOSE` 명령을 추가하세요.
+
+2.  **이미지를 빌드**하세요. `c11-app`과 같은 태그를 지정하세요.
+    ```bash
+    docker build -t c11-app .
+    ```
+
+3.  **컨테이너를 실행**하세요.
+    - 컨테이너 이름을 `c11-server`로 지정하세요.
+    - 노출된 컨테이너 포트 (`8080`)를 호스트 머신의 포트 `8011`에 게시하세요.
+
+**연습 문제를 완료하려면 컨테이너를 실행 상태로 두세요.** 검사기가 빌드된 이미지와 실행 중인 컨테이너 모두 올바르게 구성되었는지 검사합니다.

--- a/exercises/core-12/hint.md
+++ b/exercises/core-12/hint.md
@@ -14,3 +14,26 @@ services:
     # The format is a list of "HOST:CONTAINER".
     ports:
       - "6379:6379"
+```
+
+---
+
+## 한국어
+
+`docker-compose.yml` 파일은 명확한 계층 구조를 가집니다. 다음은 시작하기 위한 템플릿입니다.
+
+```yaml
+services:
+  # 서비스의 논리적 이름입니다.
+  redis-server:
+    # 사용할 이미지를 지정합니다.
+    image: redis:alpine
+    
+    # 컨테이너의 예측 가능한 이름을 설정합니다.
+    container_name: c12-redis
+    
+    # 포트 매핑을 정의합니다.
+    # 형식은 "호스트:컨테이너" 목록입니다.
+    ports:
+      - "6379:6379"
+```

--- a/exercises/core-12/prompt.md
+++ b/exercises/core-12/prompt.md
@@ -2,7 +2,7 @@ Directory: exercises/core-12
 
 So far, you've been running containers using long `docker run` commands. This is fine for one or two containers, but it quickly becomes difficult to manage as applications grow.
 
-**Docker Compose** is a tool for defining and running multi-container Docker applications. With Compose, you use a YAML file to configure your application’s services, networks, and volumes. Then, with a single command, you can create and start all the services from your configuration.
+**Docker Compose** is a tool for defining and running multi-container Docker applications. With Compose, you use a YAML file to configure your application's services, networks, and volumes. Then, with a single command, you can create and start all the services from your configuration.
 
 This is the standard way to manage local development environments.
 
@@ -17,3 +17,25 @@ Your `docker-compose.yml` file should define the following:
 4.  It should map port `6379` on your host to port `6379` in the container.
 
 After creating the file, you can test it yourself by running `docker compose up`. The verification script will run this command for you to check your work.
+
+---
+
+## 한국어
+
+지금까지 긴 `docker run` 명령을 사용하여 컨테이너를 실행해 왔습니다. 컨테이너가 하나 또는 두 개일 때는 괜찮지만, 애플리케이션이 커지면 관리하기 어려워집니다.
+
+**Docker Compose**는 멀티 컨테이너 Docker 애플리케이션을 정의하고 실행하는 도구입니다. Compose를 사용하면 YAML 파일로 애플리케이션의 서비스, 네트워크, 볼륨을 구성합니다. 그런 다음 단일 명령으로 구성에서 모든 서비스를 생성하고 시작할 수 있습니다.
+
+이것이 로컬 개발 환경을 관리하는 표준 방법입니다.
+
+## 과제
+
+이 디렉토리에 단일 Redis 서비스를 정의하는 `docker-compose.yml` 파일을 생성하는 것이 과제입니다.
+
+`docker-compose.yml` 파일은 다음을 정의해야 합니다:
+1.  `redis-server`라는 이름의 서비스.
+2.  서비스는 `redis:alpine` 이미지를 사용해야 합니다.
+3.  컨테이너 이름은 명시적으로 `c12-redis`로 지정해야 합니다.
+4.  호스트의 포트 `6379`를 컨테이너의 포트 `6379`에 매핑해야 합니다.
+
+파일을 생성한 후 `docker compose up`을 실행하여 직접 테스트할 수 있습니다. 검증 스크립트가 이 명령을 실행하여 작업을 확인합니다.

--- a/exercises/core-13/hint.md
+++ b/exercises/core-13/hint.md
@@ -20,3 +20,32 @@ services:
   redis:
     image: redis:alpine
     container_name: c13-redis
+```
+
+---
+
+## 한국어
+
+`docker-compose.yml` 파일은 이제 `services` 아래에 두 개의 최상위 키를 가집니다. 또한 `build`, `environment`, `depends_on` 키를 도입합니다.
+
+```yaml
+services:
+  # 웹 애플리케이션 서비스
+  web:
+    # Compose에게 'app' 디렉토리의 Dockerfile에서 이미지를 빌드하라고 지시합니다
+    build: ./app
+    container_name: c13-web
+    ports:
+      - "8013:5000"
+    # app.py 스크립트가 이것을 사용하여 redis 서비스에 연결합니다
+    environment:
+      - REDIS_HOST=redis
+    # 이것은 web 서비스 전에 redis 서비스가 시작되도록 보장합니다
+    depends_on:
+      - redis
+
+  # Redis 데이터베이스 서비스
+  redis:
+    image: redis:alpine
+    container_name: c13-redis
+```

--- a/exercises/core-13/prompt.md
+++ b/exercises/core-13/prompt.md
@@ -22,3 +22,30 @@ Your `docker-compose.yml` file must define two services: `web` and `redis`.
     *   Must have an environment variable `REDIS_HOST` set to `redis`. This is how the Python app knows the hostname of the Redis service on the internal Docker network.
 
 After creating the file, you can test it with `docker compose up --build`. The verification script will do this for you.
+
+---
+
+## 한국어
+
+Docker Compose의 진정한 힘은 여러 개의 상호 연결된 서비스로 구성된 전체 애플리케이션 스택을 정의하고 실행하는 것입니다.
+
+이 연습 문제에서는 Python 웹 앱과 Redis 캐시로 구성된 두 서비스 애플리케이션을 정의합니다. 또한 `depends_on`을 사용하여 Redis 서비스가 시작된 후에야 웹 앱이 시작되도록 Compose에 알려줍니다. 이는 애플리케이션 스택의 시작 순서를 제어하는 데 도움이 됩니다.
+
+## 과제
+
+웹 앱 (`app` 디렉토리에 제공됨)과 Redis 데이터베이스를 조율하는 `docker-compose.yml` 파일을 생성하세요.
+
+`docker-compose.yml` 파일은 두 서비스를 정의해야 합니다: `web`과 `redis`.
+
+1.  **`redis` 서비스:**
+    *   `redis:alpine` 이미지를 사용해야 합니다.
+    *   명확성을 위해 `c13-redis`로 이름 지정할 수 있습니다.
+
+2.  **`web` 서비스:**
+    *   `./app` 디렉토리의 `Dockerfile`에서 빌드해야 합니다.
+    *   `c13-web`으로 이름 지정해야 합니다.
+    *   호스트의 포트 `8013`을 컨테이너의 포트 `5000`에 매핑해야 합니다.
+    *   `redis` 서비스 이후에 시작되도록 `depends_on`을 사용해야 합니다.
+    *   환경 변수 `REDIS_HOST`를 `redis`로 설정해야 합니다. 이것이 Python 앱이 내부 Docker 네트워크에서 Redis 서비스의 호스트 이름을 알 수 있는 방법입니다.
+
+파일을 생성한 후 `docker compose up --build`로 테스트할 수 있습니다. 검증 스크립트가 이를 대신 수행합니다.

--- a/exercises/core-14/hint.md
+++ b/exercises/core-14/hint.md
@@ -34,3 +34,44 @@ services:
       - c14-app-net
 ```
 Note: The `redis:alpine` image is configured to automatically save its data to the `/data` directory. By mounting a volume there, we ensure the data persists.
+
+---
+
+## 한국어
+
+`docker-compose.yml`은 이제 `services` 키 외에도 최상위 `volumes`와 `networks` 키를 가져야 합니다.
+
+```yaml
+# 최상위 레벨에서 커스텀 네트워크 정의
+networks:
+  c14-app-net:
+
+# 최상위 레벨에서 명명된 볼륨 정의
+volumes:
+  redis-data:
+
+services:
+  web:
+    build: ./app
+    container_name: c14-web
+    ports:
+      - "8014:5000"
+    environment:
+      - REDIS_HOST=redis
+    depends_on:
+      - redis
+    # 이 서비스를 네트워크에 연결
+    networks:
+      - c14-app-net
+
+  redis:
+    image: redis:alpine
+    container_name: c14-redis
+    # 명명된 볼륨 마운트
+    volumes:
+      - redis-data:/data
+    # 이 서비스를 네트워크에 연결
+    networks:
+      - c14-app-net
+```
+참고: `redis:alpine` 이미지는 자동으로 데이터를 `/data` 디렉토리에 저장하도록 구성되어 있습니다. 거기에 볼륨을 마운트하면 데이터가 유지됩니다.

--- a/exercises/core-14/prompt.md
+++ b/exercises/core-14/prompt.md
@@ -24,3 +24,32 @@ Modify the `docker-compose.yml` from the previous exercise to include a named vo
     *   Map host port `8014` to container port `5000`.
 
 The directory structure and application code are the same as in the previous exercise. You only need to create and modify the `docker-compose.yml` file.
+
+---
+
+## 한국어
+
+멀티 서비스 애플리케이션을 성공적으로 조율했습니다. 이제 Docker Compose를 사용하여 강력한 데이터 지속성과 네트워킹 모범 사례를 추가할 시간입니다.
+
+- **명명된 볼륨**: 호스트의 디렉토리 구조에 의존하는 바인드 마운트와 달리, 명명된 볼륨은 Docker 자체에서 관리합니다. 데이터베이스와 같은 서비스의 데이터를 유지하는 데 선호되는 방법입니다.
+- **커스텀 네트워크**: Compose가 기본 네트워크를 생성하지만, 직접 정의하면 더 나은 격리와 조직을 제공하고 더 복잡한 네트워크 토폴로지가 가능합니다.
+
+## 과제
+
+이전 연습 문제의 `docker-compose.yml`을 수정하여 Redis 데이터용 명명된 볼륨을 포함하고 두 서비스를 커스텀 사용자 정의 네트워크에 배치하세요.
+
+1.  **최상위 `networks` 섹션을 정의**하고 `c14-app-net`이라는 네트워크를 생성하세요.
+
+2.  **최상위 `volumes` 섹션을 정의**하고 `redis-data`라는 명명된 볼륨을 생성하세요.
+
+3.  **`redis` 서비스를 수정**하세요:
+    *   컨테이너 이름을 `c14-redis`로 지정하세요.
+    *   `c14-app-net` 네트워크에 연결하세요.
+    *   `redis-data` 볼륨을 컨테이너 내부의 `/data` 디렉토리에 마운트하세요. 이곳이 Redis가 데이터를 저장하는 곳입니다.
+
+4.  **`web` 서비스를 수정**하세요:
+    *   컨테이너 이름을 `c14-web`으로 지정하세요.
+    *   `c14-app-net` 네트워크에 연결하세요.
+    *   호스트 포트 `8014`를 컨테이너 포트 `5000`에 매핑하세요.
+
+디렉토리 구조와 애플리케이션 코드는 이전 연습 문제와 동일합니다. `docker-compose.yml` 파일만 생성하고 수정하면 됩니다.

--- a/exercises/core-15/hint.md
+++ b/exercises/core-15/hint.md
@@ -30,3 +30,40 @@ EXPOSE 8080
 CMD ["/server"]
 ```
 Using `scratch` results in the smallest possible image, as it's completely empty. `alpine` is another great choice if you need a shell or other basic utilities.
+
+---
+
+## 한국어
+
+멀티 스테이지 빌드는 여러 `FROM` 명령어를 사용합니다. 각 `FROM`은 새로운 빌드 스테이지를 시작합니다. 스테이지에 이름을 지정하고 한 스테이지에서 다른 스테이지로 아티팩트를 복사할 수 있습니다.
+
+기본 구조는 다음과 같습니다:
+
+```Dockerfile
+# --- 빌드 스테이지 ---
+# "builder"와 같이 스테이지에 이름을 지정합니다
+FROM golang:1.21-alpine AS builder
+
+# 작업 디렉토리 설정
+WORKDIR /src
+
+# 소스 복사 및 정적 바이너리 빌드
+COPY app/ .
+# CGO_ENABLED=0은 'scratch'와 같은 최소 이미지에서 실행할 수 있는 정적 바이너리를 생성합니다
+RUN CGO_ENABLED=0 go build -o /app/server .
+
+
+# --- 최종 스테이지 ---
+# 최소 기본 이미지에서 새롭고 깨끗한 스테이지 시작
+FROM scratch
+
+# "builder" 스테이지에서 컴파일된 바이너리*만* 복사
+COPY --from=builder /app/server /server
+
+# 애플리케이션 포트 노출
+EXPOSE 8080
+
+# 바이너리를 실행하는 명령 설정
+CMD ["/server"]
+```
+`scratch`를 사용하면 완전히 비어 있으므로 가능한 가장 작은 이미지가 됩니다. 셸이나 기타 기본 유틸리티가 필요한 경우 `alpine`도 훌륭한 선택입니다.

--- a/exercises/core-15/prompt.md
+++ b/exercises/core-15/prompt.md
@@ -20,3 +20,28 @@ Your task is to **refactor the `Dockerfile`** to use a multi-stage build.
     *   Should set the `CMD` to run the application.
 
 The verification script will build your `Dockerfile` and check two things: that the resulting image is significantly smaller than the original single-stage build, and that the application inside it still runs correctly.
+
+---
+
+## 한국어
+
+컴파일된 애플리케이션(Go, Rust, C++ 등)을 빌드할 때, `Dockerfile`은 종종 컴파일러와 빌드 도구가 포함된 전체 SDK가 필요합니다. 그러나 최종 컨테이너는 실행하기 위해 컴파일된 바이너리만 필요합니다. 최종 이미지에 전체 SDK를 포함하면 불필요하게 커지고 보안 공격 표면이 증가합니다.
+
+**멀티 스테이지 빌드**는 이 문제를 우아하게 해결합니다. 하나의 스테이지(예: `FROM golang AS builder`)를 사용하여 코드를 컴파일하고, 두 번째 별도의 스테이지(예: `FROM scratch`)를 사용하여 최종 최소 이미지를 생성하며, 첫 번째 스테이지에서 컴파일된 바이너리*만* 복사합니다.
+
+## 과제
+
+이 디렉토리에서 간단한 Go 웹 애플리케이션과 단일 스테이지로 빌드하는 `Dockerfile`을 찾을 수 있습니다.
+
+멀티 스테이지 빌드를 사용하도록 **`Dockerfile`을 리팩토링**하는 것이 과제입니다.
+
+1.  **첫 번째 스테이지** ("빌더"):
+    *   `golang` 이미지에서 시작해야 합니다 (예: `golang:1.21-alpine`).
+    *   Go 애플리케이션 바이너리를 빌드해야 합니다.
+
+2.  **두 번째 스테이지** ("최종" 이미지):
+    *   `scratch`나 `alpine`과 같은 최소 기본 이미지에서 시작해야 합니다.
+    *   빌더 스테이지에서 컴파일된 바이너리를 최종 이미지로 복사해야 합니다.
+    *   애플리케이션을 실행하도록 `CMD`를 설정해야 합니다.
+
+검증 스크립트가 `Dockerfile`을 빌드하고 두 가지를 확인합니다: 결과 이미지가 원래 단일 스테이지 빌드보다 상당히 작은지, 그리고 그 안의 애플리케이션이 여전히 올바르게 실행되는지.


### PR DESCRIPTION
Add bilingual (English/Korean) support for all 15 exercises. Each prompt.md and hint.md now displays content in both languages, separated by a horizontal rule for clarity.