### PR TITLE
Fix core-08 to use Docker volumes instead of bind mounts

### DIFF
--- a/exercises/core-08/hint.md
+++ b/exercises/core-08/hint.md
@@ -1,17 +1,15 @@
 Follow this sequence of commands to set up the persistent database.
 
 1.  **Create the host directory:**
-    ```bash
-    mkdir pgdata
-    ```
+    `docker volume create pgdata`
 
 2.  **Run the first container instance:**
-    The `-v "$(pwd)/pgdata:/var/lib/postgresql/data"` flag maps your new local directory into the container.
+    The `-v pgdata:/var/lib/postgresql/data` flag maps your new volume into the container.
     ```bash
     docker run -d \
       --name c8-postgres \
       -e POSTGRES_PASSWORD=mysecretpassword \
-      -v "$(pwd)/pgdata":/var/lib/postgresql/data \
+      -v pgdata:/var/lib/postgresql/data \
       postgres:16
     ```
     *(Wait about 20 seconds for the database to initialize. Check its status with `docker logs c8-postgres`.)*

--- a/exercises/core-08/prompt.md
+++ b/exercises/core-08/prompt.md
@@ -1,17 +1,15 @@
 Directory: exercises/core-08
 
-Containers are ephemeral, meaning any changes made inside them are lost when they are removed. For applications like databases, the data must persist. This exercise demonstrates how **volumes** solve this by linking a directory on your host machine to a directory inside the container.
+Containers are ephemeral, meaning any changes made inside them are lost when they are removed. For applications like databases, the data must persist. This exercise demonstrates how **volumes** solve this by having Docker create a volume it manages and lets you use with the container, ensuring data persistence even if the container is removed.
 
 ## Your Task
 
 Your task is to create a persistent PostgreSQL database. You will run a container, add data to it, remove the container, and then verify that the data is still safe on your host machine.
 
-1.  **Create a directory** on your host machine named `pgdata`. This directory will hold your database files.
-    ```bash
-    mkdir pgdata
-    ```
+1.  **Create a volume** on your host machine, via Docker, named `pgdata`. This volume will be created and managed by Docker and will hold your database files.
+    `docker volume create pgdata`
 
-2.  **Run a `postgres:16` container**. Name it `c8-postgres` and use a volume to mount your `pgdata` directory to the container's data directory (`/var/lib/postgresql/data`).
+2.  **Run a `postgres:16` container**. Name it `c8-postgres` and use the volume Docker created (`pgdata`) to mount to the container's data directory (`/var/lib/postgresql/data`).
     *(Wait 15-20 seconds for the database to initialize the first time).*
 
 3.  **Create a table** using `docker exec` to run the `psql` client inside the container. The table should be named `dvd_rentals`.


### PR DESCRIPTION
- Change prompt and hint to use 'docker volume create pgdata' instead of mkdir
- Update volume mount syntax to -v pgdata:/var/lib/postgresql/data
- Update descriptions to clarify volumes vs bind mounts

Fixes #20